### PR TITLE
Replacing CTE in Deduplicate macro with Subquery #642

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Fixes
 - deduplicate macro for Databricks now uses the QUALIFY clause, which fixes NULL columns issues from the default natural join logic
 - deduplicate macro for Redshift now uses the QUALIFY clause, which fixes NULL columns issues from the default natural join logic
+- deduplicate macro now uses subquery instead of CTE to be able to call it directly without using CTE.
 
 ## Contributors:
 [@graciegoheen](https://github.com/graciegoheen)

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -4,19 +4,14 @@
 
 {%- macro default__deduplicate(relation, partition_by, order_by) -%}
 
-    with row_numbered as (
-        select
+   select
+        distinct data.*
+    from (select
             _inner.*,
             row_number() over (
                 partition by {{ partition_by }}
-                order by {{ order_by }}
-            ) as rn
-        from {{ relation }} as _inner
-    )
-
-    select
-        distinct data.*
-    from {{ relation }} as data
+                order by {{ order_by }}) as rn
+          from {{ relation }} as _inner) row_numbered
     {#
     -- Not all DBs will support natural joins but the ones that do include:
     -- Oracle, MySQL, SQLite, Redshift, Teradata, Materialize, Databricks
@@ -24,7 +19,7 @@
     -- Those that do not appear to support natural joins include:
     -- SQLServer, Trino, Presto, Rockset, Athena
     #}
-    natural join row_numbered
+    natural join {{ relation }} data
     where row_numbered.rn = 1
 
 {%- endmacro -%}


### PR DESCRIPTION
resolves #

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [x] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
